### PR TITLE
add forceUpdate to QueryView

### DIFF
--- a/src/test/scala/akka/contrib/persistence/query/QueryViewSnapshotSerializerSpec.scala
+++ b/src/test/scala/akka/contrib/persistence/query/QueryViewSnapshotSerializerSpec.scala
@@ -2,12 +2,11 @@ package akka.contrib.persistence.query
 
 import java.nio.ByteBuffer
 
-import akka.persistence.query.{Offset, Sequence}
+import akka.persistence.query.Sequence
 import akka.serialization.SerializationExtension
 import com.ovoenergy.UnitSpec
 import com.ovoenergy.akka.AkkaFixture
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 
 import scala.util.{Failure, Try}
 


### PR DESCRIPTION
-forceUpdate uses the stream defined as recoveryStream and instantly fetches the latest changes instead of waiting for the liveStream (most plugins use polling)
-filter already processed events within receive and not within the stream (fixes concurrency issues)
-assert events are received in order ->this is only true for PersistentQuery byPersistenceId and does not work for byTag (currently only making this visible -> this means queryView using byTag needs to `override def allowOutOfOrderEvents = true` )