### PR TITLE
Ordered events

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ class PersonsQueryView extends QueryView with LevelDbQuerySupport {
 
 Under the hood it will store also the last consumed offset and the last sequence number for each persistence id already consumed.
 
-The QueryView checks that all received events follow a strict sequence per persistentId. Be aware that most journal plugins do not guarantee the correct order for `eventsByTag` (see journal documentation). 
-If that is ok one can overwrite `override def allowOutOfOrderEvents = true` to omit the checking. (In the future we might implement some deferred processing of out of order received events)
+The QueryView checks that all received events follow a strict sequence per persistentId. Events read out of order are held in memory and only applied once all previous events have been received.
 
 ### Forced Update
 Most journals use some sort of polling under the hood to support a live stream for `eventsByTag/eventsByPersistentId` PersistentQueries. (The default cassandra journal uses 3 seconds)

--- a/build.sbt
+++ b/build.sbt
@@ -60,10 +60,11 @@ lazy val `akka-persistence-query-view` = (project in file("."))
       "proto" -> Apache2_0("2016", "OVO Energy", "//"),
       "scala" -> Apache2_0("2016", "OVO Energy"),
       "conf" -> Apache2_0("2016", "OVO Energy", "#")
-    ),
-    tutSettings,
-    tutTargetDirectory := baseDirectory.value,
-    bintrayOrganization := Some("ovotech"),
-    bintrayRepository := "maven",
-    bintrayPackageLabels := Seq("akka", "akka-persistence", "event-sourcing", "cqrs")
+    )
+//    ,
+//    tutSettings,
+//    tutTargetDirectory := baseDirectory.value,
+//    bintrayOrganization := Some("ovotech"),
+//    bintrayRepository := "maven",
+//    bintrayPackageLabels := Seq("akka", "akka-persistence", "event-sourcing", "cqrs")
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.1")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0-8-g6d0c3f8")
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.8")
+//addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0-8-g6d0c3f8")
+//addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.8")
 
 // To resolve custom bintray-sbt plugin
 resolvers += Resolver.url("2m-sbt-plugin-releases", url("https://dl.bintray.com/2m/sbt-plugin-releases/"))(

--- a/src/main/scala/akka/contrib/persistence/query/QuerySupport.scala
+++ b/src/main/scala/akka/contrib/persistence/query/QuerySupport.scala
@@ -33,7 +33,7 @@ trait LevelDbQuerySupport extends QuerySupport {
   this: QueryView =>
 
   override type Queries = LeveldbReadJournal
-  override def firstOffset: OT = Sequence(1L)
+  override def firstOffset: OT = Sequence(0L)
   override val queries: LeveldbReadJournal =
     PersistenceQuery(context.system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
 }

--- a/src/main/scala/akka/contrib/persistence/query/QueryViewSnapshot.scala
+++ b/src/main/scala/akka/contrib/persistence/query/QueryViewSnapshot.scala
@@ -16,6 +16,6 @@
 
 package akka.contrib.persistence.query
 
-import akka.persistence.query.Sequence
+import akka.persistence.query.Offset
 
-case class QueryViewSnapshot[T](data: T, maxOffset: Sequence, sequenceNrs: Map[String, Long] = Map.empty)
+case class QueryViewSnapshot[T](data: T, maxOffset: Offset, sequenceNrs: Map[String, Long] = Map.empty)


### PR DESCRIPTION
Adds guaranteed ordering of events per persistenceId. Future events received out of order are stored and immediately applied as soon as all past events are processed.
#allowOutOfOrderEvents is not needed anymore and has been dropped.
Also add #currentEvent to allow a view to see the persistenceId/sequenceNr of the currently processed event.
Also fixed noOfEventsSinceLastSnapshot (also counted other custom messages as events).
