### PR TITLE
ONB-562: Live events not picked up.

### DIFF
--- a/src/main/scala/akka/persistence/QueryView.scala
+++ b/src/main/scala/akka/persistence/QueryView.scala
@@ -378,7 +378,7 @@ abstract class QueryView
       case LoadSnapshotFailed(ex) ⇒
         // It is recoverable so we don't need to crash the actor
         log.error(ex, s"Error loading the snapshot")
-        loadSnapshot()
+        startRecovery()
 
       case _ ⇒
         recoveringStash.stash()

--- a/src/main/scala/akka/persistence/QueryView.scala
+++ b/src/main/scala/akka/persistence/QueryView.scala
@@ -230,7 +230,7 @@ abstract class QueryView
   private def loadSnapshot(): Unit = {
     // If the `loadSnapshotTimeout` is finite, it makes sure the Actor will not get stuck in 'waitingForSnapshot' state.
     loadSnapshotTimer = loadSnapshotTimeout match {
-      case timeout: FiniteDuration ⇒
+      case timeout: FiniteDuration =>
         Some(
           context.system.scheduler.scheduleOnce(
             timeout,
@@ -238,7 +238,7 @@ abstract class QueryView
             LoadSnapshotTimeout
           )
         )
-      case _ ⇒
+      case _ =>
         None
     }
     currentState = State.WaitingForSnapshot
@@ -275,27 +275,27 @@ abstract class QueryView
       case StartLive =>
         sender() ! EventReplayed
 
-      case EventEnvelope2(offset: OT, persistenceId, sequenceNr, event) ⇒
+      case EventEnvelope2(offset: OT, persistenceId, sequenceNr, event) =>
         processEvent(behaviour, offset, persistenceId, sequenceNr, event)
         sender() ! EventReplayed
 
-      case EventEnvelope(offset, persistenceId, sequenceNr, event) ⇒
+      case EventEnvelope(offset, persistenceId, sequenceNr, event) =>
         processEvent(behaviour, Sequence(offset), persistenceId, sequenceNr, event)
         sender() ! EventReplayed
 
-      case LiveStreamFailed(ex) ⇒
+      case LiveStreamFailed(ex) =>
         log.error(ex, s"Live stream failed, it is a fatal error")
         // We have to crash the actor
         throw ex
 
-      case ForceUpdate ⇒
+      case ForceUpdate =>
         startForceUpdate()
 
-      case StartForceUpdate ⇒
+      case StartForceUpdate =>
         log.debug("update stream started")
         sender() ! EventReplayed
 
-      case ForceUpdateCompleted ⇒
+      case ForceUpdateCompleted =>
         forcedUpdateInProgress = false
         onForceUpdateCompleted()
 
@@ -355,7 +355,7 @@ abstract class QueryView
       case LoadSnapshotFailed(ex) =>
         log.error(ex, "Unexpected snapshot failed error while recovering.")
 
-      case other ⇒
+      case other =>
         log.debug(s"Stashing while recovering: [$other]")
         recoveringStash.stash()
     }
@@ -384,10 +384,10 @@ abstract class QueryView
         }
         startRecovery()
 
-      case LoadSnapshotResult(None, _) ⇒
+      case LoadSnapshotResult(None, _) =>
         startRecovery()
 
-      case LoadSnapshotTimeout ⇒
+      case LoadSnapshotTimeout =>
         // It is recoverable so we don't need to crash the actor
         log.error(s"Timeout loading the snapshot after [$loadSnapshotTimeout]")
         startRecovery()
@@ -399,7 +399,7 @@ abstract class QueryView
       case LiveStreamFailed(ex) =>
         log.error(ex, s"Live stream failed while waiting for snapshot, ignoring...")
 
-      case other: Any ⇒
+      case other =>
         log.debug(s"Stashing while waiting for snapshot: [$other]")
         recoveringStash.stash()
     }
@@ -410,8 +410,8 @@ abstract class QueryView
     currentState = State.Recovering
 
     val stream = recoveryTimeout match {
-      case t: FiniteDuration ⇒ recoveringStream(_sequenceNrByPersistenceId, lastOffset).completionTimeout(t)
-      case _ ⇒ recoveringStream(_sequenceNrByPersistenceId, lastOffset)
+      case t: FiniteDuration => recoveringStream(_sequenceNrByPersistenceId, lastOffset).completionTimeout(t)
+      case _ => recoveringStream(_sequenceNrByPersistenceId, lastOffset)
     }
 
     val recoverySink =

--- a/src/main/scala/akka/persistence/QueryView.scala
+++ b/src/main/scala/akka/persistence/QueryView.scala
@@ -378,7 +378,7 @@ abstract class QueryView
       case LoadSnapshotFailed(ex) ⇒
         // It is recoverable so we don't need to crash the actor
         log.error(ex, s"Error loading the snapshot")
-        startRecovery()
+        loadSnapshot()
 
       case _ ⇒
         recoveringStash.stash()

--- a/src/test/scala/akka/persistence/QueryViewSpec.scala
+++ b/src/test/scala/akka/persistence/QueryViewSpec.scala
@@ -10,6 +10,7 @@ import akka.testkit.TestProbe
 import akka.util.Timeout
 import com.ovoenergy.akka.{AkkaFixture, AkkaPersistenceFixture}
 import com.ovoenergy.{ConfigFixture, UnitSpec}
+import org.scalatest.Assertion
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
@@ -32,12 +33,7 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
           writeToJournal("test-2", Tagged("test-2-2", Set("two")))
           writeToJournal("test-1", Tagged("test-1-3", Set("one")))
 
-          val expectedMessages = Seq("test-1-1", "test-1-2", "test-1-3")
-
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-1-2", "test-1-3"))
         }
       }
 
@@ -52,12 +48,7 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
 
           restartUnderTest()
 
-          val expectedMessages = Seq("test-1-1", "test-1-2", "test-1-3")
-
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-1-2", "test-1-3"))
         }
 
         "continue receiving live events with the given persistenceId" in new PersistenceIdQueryViewContext("test-1") {
@@ -73,17 +64,10 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
           writeToJournal("test-1", Tagged("test-1-4", Set("one")))
           writeToJournal("test-2", Tagged("test-2-3", Set("one")))
 
-          val expectedMessages = Seq("test-1-1", "test-1-2", "test-1-3", "test-1-4")
-
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-1-2", "test-1-3", "test-1-4"))
         }
 
-        "receives events from new recoverystream on force update" in new PersistenceIdQueryViewContextOnlyRecoveryStream(
-          "test-1"
-        ) {
+        "receives events from new recoverystream on force update" in new PersistenceIdQueryViewContextOnlyRecoveryStream("test-1") {
 
           writeToJournal("test-1", Tagged("test-1-1", Set("one")))
           writeToJournal("test-1", Tagged("test-1-2", Set("two")))
@@ -102,12 +86,7 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
           writeToJournal("test-1", Tagged("test-1-4", Set("one")))
           writeToJournal("test-2", Tagged("test-2-3", Set("one")))
 
-          val expectedMessages = Seq("test-1-1", "test-1-2", "test-1-3", "test-1-4")
-          eventually {
-            forceUpdate()
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-1-2", "test-1-3", "test-1-4"), update = true)
         }
 
         "load status from snapshot and receive journal events" in new PersistenceIdQueryViewContext("test-1") {
@@ -126,12 +105,7 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
 
           restartUnderTest()
 
-          val expectedMessages = Seq("test-1-1", "test-1-2", "test-1-3", "test-1-4")
-
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-1-2", "test-1-3", "test-1-4"))
         }
       }
     }
@@ -146,12 +120,7 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
           writeToJournal("test-1", Tagged("test-1-2", Set("one")))
           writeToJournal("test-3", Tagged("test-3-2", Set("two")))
 
-          val expectedMessages = Seq("test-1-1", "test-3-1", "test-1-2")
-
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-3-1", "test-1-2"))
         }
       }
       "is restarted" should {
@@ -166,12 +135,7 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
 
           restartUnderTest()
 
-          val expectedMessages = Seq("test-1-1", "test-3-1", "test-1-2")
-
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-3-1", "test-1-2"))
         }
 
         "continue receiving live events with the given tag" in new TagQueryViewContext("one") {
@@ -187,12 +151,7 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
           writeToJournal("test-1", Tagged("test-1-4", Set("one")))
           writeToJournal("test-2", Tagged("test-2-3", Set("one", "two")))
 
-          val expectedMessages = Seq("test-1-1", "test-2-1", "test-1-3", "test-1-4", "test-2-3")
-
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-2-1", "test-1-3", "test-1-4", "test-2-3"))
         }
 
         "receives events from new recoverystream on force update" in new TagQueryViewContextOnlyRecoveryStream("one") {
@@ -205,21 +164,12 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
 
           restartUnderTest()
 
-          val recoveryMessages = Seq("test-1-1", "test-2-1", "test-1-3")
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs recoveryMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-2-1", "test-1-3"))
 
           writeToJournal("test-1", Tagged("test-1-4", Set("one")))
           writeToJournal("test-2", Tagged("test-2-3", Set("one")))
 
-          val expectedMessages = Seq("test-1-1", "test-2-1", "test-1-3", "test-1-4", "test-2-3")
-          eventually {
-            forceUpdate()
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
+          assertGetMessages(Seq("test-1-1", "test-2-1", "test-1-3", "test-1-4", "test-2-3"), update = true)
         }
 
         "load status from snapshot and receive journal events" in new TagQueryViewContext("one") {
@@ -238,29 +188,30 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
 
           restartUnderTest()
 
-          val expectedMessages = Seq("test-1-1", "test-2-1", "test-1-3", "test-1-4", "test-2-3")
+          assertGetMessages(Seq("test-1-1", "test-2-1", "test-1-3", "test-1-4", "test-2-3"))
 
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs expectedMessages
-          }
         }
 
         "recover from failure in live stream" in new FailingLiveQueryViewContext("one") {
           writeToJournal("test-1", Tagged("test-1-1", Set("one")))
           writeToJournal("test-1", Tagged("test-1-2", Set("one")))
 
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs Seq("test-1-1", "test-1-2")
-          }
+          assertGetMessages(Seq("test-1-1", "test-1-2"))
 
           writeToJournal("test-1", Tagged("test-1-3", Set("one")))
 
-          eventually {
-            val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
-            receivedMessages should contain theSameElementsInOrderAs Seq("test-1-1", "test-1-2", "test-1-3")
-          }
+          assertGetMessages(Seq("test-1-1", "test-1-2", "test-1-3"))
+        }
+
+        "recover from child exception" in new TagQueryViewContext("one") {
+          writeToJournal("test-1", Tagged("test-1-1", Set("one")))
+          writeToJournal("test-1", Tagged("test-1-2", Set("one")))
+
+          assertGetMessages(Seq("test-1-1", "test-1-2"))
+
+          throwException()
+
+          assertGetMessages(Seq("test-1-1", "test-1-2"))
         }
       }
     }
@@ -280,6 +231,11 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
       _underTest = createUnderTest()
     }
 
+    def throwException(): Unit = {
+      val probe = TestProbe()
+      probe.send(underTest, ThrowException)
+    }
+
     protected def createUnderTest(): ActorRef
 
     def saveSnapshot(): Unit = {
@@ -291,6 +247,14 @@ class QueryViewSpec extends UnitSpec with ConfigFixture with AkkaFixture with Ak
     def forceUpdate(): Unit = {
       val probe = TestProbe()
       probe.send(underTest, ForceUpdate)
+    }
+
+    def assertGetMessages(messages: Seq[String], update: Boolean = false): Assertion = {
+      eventually {
+        if (update) forceUpdate()
+        val receivedMessages = underTest.ask(GetMessage).mapTo[Vector[String]].futureValue
+        receivedMessages should contain theSameElementsInOrderAs messages
+      }
     }
   }
 
@@ -382,6 +346,7 @@ object TestQueryView {
   val GetMessage = "GetMessages"
   val SaveSnapshot = "SaveSnapshot"
   val SnapshotSaved = "SnapshotSaved"
+  val ThrowException = "ThrowException"
 }
 
 abstract class TestQueryView extends QueryView with LevelDbQuerySupport {
@@ -409,6 +374,9 @@ abstract class TestQueryView extends QueryView with LevelDbQuerySupport {
     case SaveSnapshotFailure(_, error) =>
       waitForSnapshot.foreach(_ ! Status.Failure(error))
       waitForSnapshot = None
+
+    case ThrowException =>
+      throw new RuntimeException("???")
 
     case SnapshotOffer(_, snapshot: Vector[String]) =>
       messages = snapshot


### PR DESCRIPTION
If query view actor fails with exception, it is restarted and enters limbo recovery snapshot state. This PR makes sure, that the recovery logic is called when the actor restarts.

This PR also addresses issue with `aroundPreStart` which might be difficult to spot in `Files changed` section. `aroundPreStart` method used to call `super.aroundPreStart` as the first statement, which was invalid.