### PR TITLE
more flexible offset handling for snapshots

### DIFF
--- a/src/main/scala/akka/contrib/persistence/query/QueryViewSnapshot.scala
+++ b/src/main/scala/akka/contrib/persistence/query/QueryViewSnapshot.scala
@@ -16,6 +16,6 @@
 
 package akka.contrib.persistence.query
 
-import akka.persistence.query.Sequence
+import akka.persistence.query.Offset
 
-case class QueryViewSnapshot[T](data: T, maxOffset: Sequence, sequenceNrs: Map[String, Long] = Map.empty)
+case class QueryViewSnapshot[T](data: T, maxOffset: Offset, sequenceNrs: Map[String, Long] = Map.empty)

--- a/src/main/scala/akka/contrib/persistence/query/QueryViewSnapshotSerializer.scala
+++ b/src/main/scala/akka/contrib/persistence/query/QueryViewSnapshotSerializer.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 
 import akka.actor.ExtendedActorSystem
 import akka.contrib.persistence.query.QueryViewFormats.Payload
-import akka.persistence.query.Sequence
+import akka.persistence.query.Offset
 import akka.protobuf.ByteString
 import akka.serialization.{BaseSerializer, ByteBufferSerializer, SerializationExtension, SerializerWithStringManifest}
 
@@ -87,7 +87,7 @@ class QueryViewSnapshotSerializer(val system: ExtendedActorSystem) extends BaseS
     }
 
     val data = deserializePayload(parsed.getData)
-    val maxOffset = deserializePayload(parsed.getMaxOffset).asInstanceOf[Sequence]
+    val maxOffset = deserializePayload(parsed.getMaxOffset).asInstanceOf[Offset]
 
     QueryViewSnapshot(data, maxOffset, sequenceNrsBuilder.result())
   }

--- a/src/main/scala/akka/persistence/QueryView.scala
+++ b/src/main/scala/akka/persistence/QueryView.scala
@@ -377,7 +377,7 @@ abstract class QueryView
         val offer = SnapshotOffer(metadata, status.data)
         if (behaviour.isDefinedAt(offer)) {
           super.aroundReceive(behaviour, offer)
-          _lastOffset = status.maxOffset
+          _lastOffset = status.maxOffset.asInstanceOf[OT]
           _sequenceNrByPersistenceId = status.sequenceNrs
           lastSnapshotSequenceNr = metadata.sequenceNr
         }


### PR DESCRIPTION
Cassandra uses TimeBasedUUID offset, therefore it must be handled more flexible.